### PR TITLE
Update test CMakeLists.txt so you can build unittests on MacOS or directly

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,8 @@
+cmake_minimum_required(VERSION 3.8)
 enable_testing()
+set (CMAKE_CXX_STANDARD 11)
 find_package(GTest REQUIRED)
 include_directories(${GTEST_INCLUDE_DIRS})
-
 find_package( Threads )
 
 add_executable (run_tests main.cpp)


### PR DESCRIPTION
I found that I could not build the unittests directly using cmake on Sierra.

Newer versions of cmake require cmake_minimum_required, which is a good thing. I put it at 3.8.0, and add set (CMAKE_CXX_STANDARD 11) in the file so it can compile the C++11 semantics.

