### PR TITLE
Fix various typos found by crate-ci typo checker.

### DIFF
--- a/BENCHMARKING.md
+++ b/BENCHMARKING.md
@@ -55,7 +55,7 @@ The benchmark name contains the following information:
 	* The number of times the benchmarked operation (insert) is executed on that tree (1000 in this case)
 	* The random seed used (4)
 	
-The two other colums list the wall time elapsed, the CPU time elapsed, and the number of times that the Google Benchmark framework executed the benchmark.
+The two other columns list the wall time elapsed, the CPU time elapsed, and the number of times that the Google Benchmark framework executed the benchmark.
 
 Several parameters can be controlled via command-line switches. The binaries accept all parameters usually acceptey by Google Benchmark [2] - see the respective documentation especially on how to control output format. Additional command-line parameters are:
 
@@ -66,7 +66,7 @@ Several parameters can be controlled via command-line switches. The binaries acc
 	* --experiment_size: The number of times that the operation to be benchmarked should be executed on the initially generated tree. Note that for some operations (delete, erase), it does not make sense to set experiment_size larger than base_size.
 	* --filter: Allows to specify a regular expression on the 'benchmark name' field to filter benchmarks.
 	
-So, for example, running `--base_size 1024 --doublings 3 --seed_start 42 --seed_count 2` would execute each bechmark eight times: For tree sizes of 1024, 2048, 4096 and 8192, each with the seeds 42 and 43.
+So, for example, running `--base_size 1024 --doublings 3 --seed_start 42 --seed_count 2` would execute each benchmark eight times: For tree sizes of 1024, 2048, 4096 and 8192, each with the seeds 42 and 43.
 
 
 Troubleshooting

--- a/benchmark/random.cpp
+++ b/benchmark/random.cpp
@@ -104,7 +104,7 @@ ZipfDistr::ZipfSampler::h_integral_inverse(double x) const noexcept
 double
 ZipfDistr::ZipfSampler::helper1(double x) const noexcept
 {
-	// Originial implementation uses a tailor expansion for small x
+	// Original implementation uses a tailor expansion for small x
 	if (std::abs(x) > 1e-8) {
 		return std::log1p(x) / x;
 	} else {

--- a/src/energy.hpp
+++ b/src/energy.hpp
@@ -133,7 +133,7 @@ public:
 	 * *Warning*: Please note that after calling insert() on a node (and before
 	 * removing that node again), that node *may not move in memory*. A common
 	 * pitfall is to store nodes in a std::vector (or other STL container), which
-	 * reallocates (and thereby moves objecs around).
+	 * reallocates (and thereby moves objects around).
 	 *
 	 * @warning Not available for explicitly ordered trees
 	 *

--- a/src/intervaltree.cpp
+++ b/src/intervaltree.cpp
@@ -295,7 +295,7 @@ IntervalTree<Node, NodeTraits, Options, Tag>::find_fast(const Comparable & q)
 		}
 	}
 
-	// Step 2: Search on upper bounds. Esentially the same as before, but we must
+	// Step 2: Search on upper bounds. Essentially the same as before, but we must
 	// make sure never to leave the range of nodes with correct lower bounds.
 	while ((cur != nullptr) && (NodeTraits::get_lower(*cur) == q_lower)) {
 		if constexpr (Options::micro_prefetch) {
@@ -383,7 +383,7 @@ Node *
 find_next_overlapping(Node * cur, const Comparable & q)
 {
 	// We search for the next bigger node, pruning the search as necessary. When
-	// Pruning occurrs, we need to restart the search for the next larger node.
+	// Pruning occurs, we need to restart the search for the next larger node.
 
 	do {
 		// We make sure that at the start of the loop, the lower of cur is smaller

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -238,7 +238,7 @@ public:
 	 * https://www.cambridge.org/core/journals/journal-of-functional-programming/article/balancing-weightbalanced-trees/7281C4DE7E56B74F2D13F06E31DCBC5B
 	 * for information on Delta.
 	 *
-	 * Note that setting this to 1 (i.e., chosing an integral Delta) improves
+	 * Note that setting this to 1 (i.e., choosing an integral Delta) improves
 	 * performance.
 	 *
 	 * @tparam delta_numerator The denominator of Delta
@@ -257,7 +257,7 @@ public:
 	 * https://www.cambridge.org/core/journals/journal-of-functional-programming/article/balancing-weightbalanced-trees/7281C4DE7E56B74F2D13F06E31DCBC5B
 	 * for information on Gamma.
 	 *
-	 * Note that setting this to 1 (i.e., chosing an integral Gamma) improves
+	 * Note that setting this to 1 (i.e., choosing an integral Gamma) improves
 	 * performance.
 	 *
 	 * @tparam delta_numerator The denominator of Gamma
@@ -301,7 +301,7 @@ public:
 	 *
 	 * Enabling this will cause the various data structures to enable tricks to
 	 * avoid conditional branching, using e.g. pointer arithmetic instead. This
-	 * can siginificantly increase performance on certain architectures, e.g.
+	 * can significantly increase performance on certain architectures, e.g.
 	 * modern SkyLake CPUs. However, if you enable this, make sure you profile
 	 * your performance to determine whether this actually helps with your
 	 * specific workload.

--- a/src/rbtree.hpp
+++ b/src/rbtree.hpp
@@ -238,7 +238,7 @@ public:
 	 * *Warning*: Please note that after calling insert() on a node (and before
 	 * removing that node again), that node *may not move in memory*. A common
 	 * pitfall is to store nodes in a std::vector (or other STL container), which
-	 * reallocates (and thereby moves objecs around).
+	 * reallocates (and thereby moves objects around).
 	 *
 	 * @warning Not available for explicitly ordered trees
 	 *

--- a/src/wbtree.cpp
+++ b/src/wbtree.cpp
@@ -1169,7 +1169,7 @@ WBTree<Node, NodeTraits, Options, Tag, Compare>::remove_onepass(Node & node)
 		// std::cout << "-- Deleting from left.\n";
 
 		Node * n_l = cur->NB::get_left();
-		size_t s_left = n_l->NB::_wbt_size - 1; // deletion occurrs here
+		size_t s_left = n_l->NB::_wbt_size - 1; // deletion occurs here
 		cur->NB::_wbt_size -= 1;
 		s_cur = cur->NB::_wbt_size;
 		size_t s_right = s_cur - s_left;
@@ -1207,7 +1207,7 @@ WBTree<Node, NodeTraits, Options, Tag, Compare>::remove_onepass(Node & node)
 			}
 		}
 
-		// We descend to the left, as decided ealier.
+		// We descend to the left, as decided earlier.
 		cur = n_l;
 		s_cur = s_left;
 
@@ -1261,7 +1261,7 @@ WBTree<Node, NodeTraits, Options, Tag, Compare>::remove_onepass(Node & node)
 		// std::cout << "-- Deleting from right.\n";
 
 		Node * n_r = cur->NB::get_right();
-		size_t s_right = n_r->NB::_wbt_size - 1; // deletion occurrs here
+		size_t s_right = n_r->NB::_wbt_size - 1; // deletion occurs here
 		cur->NB::_wbt_size -= 1;
 		s_cur = cur->NB::_wbt_size;
 		size_t s_l = s_cur - s_right;
@@ -1290,14 +1290,14 @@ WBTree<Node, NodeTraits, Options, Tag, Compare>::remove_onepass(Node & node)
 				this->rotate_right(cur);
 
 			} else {
-				// Sinlge Rotation
+				// Single Rotation
 				// std::cout << " ---- Single rotation around " << std::hex << cur
 				// << std::dec << ".\n";
 				this->rotate_right(cur);
 			}
 		}
 
-		// We descend to the right, as decided ealier.
+		// We descend to the right, as decided earlier.
 		cur = n_r;
 		s_cur = s_right;
 

--- a/src/wbtree.hpp
+++ b/src/wbtree.hpp
@@ -180,7 +180,7 @@ public:
 	 * *Warning*: Please note that after calling insert() on a node (and before
 	 * removing that node again), that node *may not move in memory*. A common
 	 * pitfall is to store nodes in a std::vector (or other STL container), which
-	 * reallocates (and thereby moves objecs around).
+	 * reallocates (and thereby moves objects around).
 	 *
 	 * @warning Not available for explicitly ordered trees
 	 *

--- a/src/ziptree.hpp
+++ b/src/ziptree.hpp
@@ -256,7 +256,7 @@ public:
 	 * *Warning*: Please note that after calling insert() on a node (and before
 	 * removing that node again), that node *may not move in memory*. A common
 	 * pitfall is to store nodes in a std::vector (or other STL container), which
-	 * reallocates (and thereby moves objecs around).
+	 * reallocates (and thereby moves objects around).
 	 *
 	 * For zip trees, the hinted version is equivalent to the unhinted insertion.
 	 *

--- a/test/test_dynamic_segment_tree_base.hpp
+++ b/test/test_dynamic_segment_tree_base.hpp
@@ -150,7 +150,7 @@ TEST(__DST_BASENAME(DynSegTreeTest), TestEventBounding)
 	it = agg.upper_bound_event(2);
 	ASSERT_EQ(it, agg.begin() + 1);
 
-	// Note that the 5) border is open - thus, lower-bouding on 5 actually
+	// Note that the 5) border is open - thus, lower-bounding on 5 actually
 	// correctly gives the end iterator!
 	it = agg.lower_bound_event(5);
 	ASSERT_EQ(it, agg.end());


### PR DESCRIPTION
Found via a typo checker we have in our project that uses ygg.  Hopefully I didn't get any of these wrong :P